### PR TITLE
design/ItemDetail/#45

### DIFF
--- a/src/pages/ItemDetail/index.tsx
+++ b/src/pages/ItemDetail/index.tsx
@@ -67,14 +67,14 @@ export const ItemDetail = () => {
           </S.ItemTextArea>
         </S.DetailArea>
       </S.DetailContainer>
-      <S.DesContainer style={{ height: desHeight }}>
+      <S.DesContainer style={{ height: desHeight, marginBottom: desToggle ? '' : 194 }}>
         <S.Description id='description'>
           <div style={{ fontSize: '3rem' }}>{state.data.description}</div>
         </S.Description>
         <S.DesGradation style={{ display: desToggle ? 'inherit' : 'none' }} />
       </S.DesContainer>
-      <S.ShowDesBtnContainer>
-        <S.ShowDesBtn style={{ display: desToggle ? 'flex' : 'none' }} onClick={() => desEvent()}>
+      <S.ShowDesBtnContainer style={{ display: desToggle ? 'flex' : 'none' }}>
+        <S.ShowDesBtn onClick={() => desEvent()}>
           <span>상세페이지 더보기</span>
           <AiOutlineDown style={{ width: 28, height: 24 }} />
         </S.ShowDesBtn>

--- a/src/pages/ItemDetail/index.tsx
+++ b/src/pages/ItemDetail/index.tsx
@@ -1,24 +1,40 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import * as S from './style';
 import { Nav } from '../../components/item/Nav';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { AiOutlineDown } from 'react-icons/ai';
 
 export const ItemDetail = () => {
   const { state } = useLocation();
   const navigate = useNavigate();
-  let itemNav = document.querySelector('#item-nav') as HTMLElement | null;
-  let itemNavTop = 470;
-  if (itemNav !== null) {
-    itemNavTop = itemNav.offsetTop;
+  const [desHeight, setDesHeight] = useState(0);
+  const [desToggle, setDesToggle] = useState(false);
+  const [itemNavTop, setItemNavTop] = useState(0);
+  let purchaseBtn = <S.PurchaseBtn onClick={() => moveOders()}>구매하기</S.PurchaseBtn>;
+  if (state.data.price === null) {
+    purchaseBtn = <S.PurchaseBtn>견적서 요청</S.PurchaseBtn>;
   }
   useEffect(() => {
+    if ((document.querySelector('#description') as HTMLElement).offsetHeight <= 1836) {
+      setDesHeight((document.querySelector('#description') as HTMLElement).offsetHeight);
+    } else {
+      setDesHeight(1836);
+      setDesToggle(true);
+    }
+  }, []);
+  useEffect(() => {
+    setItemNavTop((document.querySelector('#item-nav') as HTMLElement).offsetTop);
     window.scrollTo({
       top: itemNavTop,
       behavior: 'smooth',
     });
-  });
+  }, [itemNavTop]);
   const moveOders = () => {
     navigate('/orders');
+  };
+  const desEvent = () => {
+    setDesHeight((document.querySelector('#description') as HTMLElement).offsetHeight);
+    setDesToggle(false);
   };
   return (
     <S.Container>
@@ -41,16 +57,28 @@ export const ItemDetail = () => {
                 {state.data.price
                   ? state.data.price.toString().replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ',') +
                     '원'
-                  : '금액표시없음'}
+                  : '관리자 문의'}
               </S.Price>
             </S.PriceArea>
             <S.BtnArea>
               <S.BasketBtn>장바구니</S.BasketBtn>
-              <S.PurchaseBtn onClick={() => moveOders()}>구매하기</S.PurchaseBtn>
+              {purchaseBtn}
             </S.BtnArea>
           </S.ItemTextArea>
         </S.DetailArea>
       </S.DetailContainer>
+      <S.DesContainer style={{ height: desHeight }}>
+        <S.Description id='description'>
+          <div style={{ fontSize: '3rem' }}>{state.data.description}</div>
+        </S.Description>
+        <S.DesGradation style={{ display: desToggle ? 'inherit' : 'none' }} />
+      </S.DesContainer>
+      <S.ShowDesBtnContainer>
+        <S.ShowDesBtn style={{ display: desToggle ? 'flex' : 'none' }} onClick={() => desEvent()}>
+          <span>상세페이지 더보기</span>
+          <AiOutlineDown style={{ width: 28, height: 24 }} />
+        </S.ShowDesBtn>
+      </S.ShowDesBtnContainer>
     </S.Container>
   );
 };

--- a/src/pages/ItemDetail/style.ts
+++ b/src/pages/ItemDetail/style.ts
@@ -14,7 +14,7 @@ export const DetailArea = styled.div`
   width: 144rem;
   height: 78rem;
   margin-top: 8.3rem;
-  border-bottom: 1px solid #000000;
+  border-bottom: 0.1rem solid #000000;
   display: flex;
   flex-diretion: row;
   margin-bottom: 17.6rem;
@@ -72,7 +72,7 @@ export const BasketBtn = styled(Btn)`
 `;
 export const PurchaseBtn = styled(Btn)`
   background-color: #ffffff;
-  border: 1px solid ${(props) => props.theme.palette.green};
+  border: 0.1rem solid ${(props) => props.theme.palette.green};
   color: ${(props) => props.theme.palette.green};
 `;
 export const DesContainer = styled.div`

--- a/src/pages/ItemDetail/style.ts
+++ b/src/pages/ItemDetail/style.ts
@@ -75,3 +75,42 @@ export const PurchaseBtn = styled(Btn)`
   border: 1px solid ${(props) => props.theme.palette.green};
   color: ${(props) => props.theme.palette.green};
 `;
+export const DesContainer = styled.div`
+  width: 100%;
+  ${({ theme }) => theme.common.flexCenter};
+  overflow: hidden;
+  align-items: flex-start;
+  position: relative;
+`;
+export const Description = styled.div`
+  width: 86rem;
+  height: 300rem;
+  background-color: #f8f7bc;
+`;
+export const DesGradation = styled.div`
+  width: 86rem;
+  height: 16rem;
+  position: absolute;
+  background: linear-gradient(#ffffff 0%, rgba(255, 255, 255, 0) 100%, #ffffff 100%);
+  bottom: 0;
+  transform: rotate(180deg);
+`;
+export const ShowDesBtnContainer = styled.div`
+  width: 100%;
+  height: 8.1rem;
+  ${({ theme }) => theme.common.flexCenter};
+  margin-top: 3.6rem;
+  margin-bottom: 20.1rem;
+`;
+export const ShowDesBtn = styled.div`
+  width: 23.9rem;
+  height: 100%;
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  flex-direction: column;
+  font-size: 3.12rem;
+  font-weight: 400;
+  color: #000000;
+  cursor: pointer;
+`;


### PR DESCRIPTION
## ⭐ 개요
ItemDetail

## 📋 작업사항
- [x] 가격이 없는 아이템의 가격부분 관리자 문의로 변경 되도록 설정
- [x] 가격이 없는 아이템 구매하기버튼을 견적서 요청 버튼으로 변경 되도록 설정
- [x] description height가 1836px 보다 작은 경우 전체 내용을 보여준다.
- [x] description height가 1836px 보다 큰 경우 1836px의 크기로 자르고 상세페이지 더보기 버튼 생성
- [x] 상세페이지 더보기 버튼을 누르면 전체 내용을 다 보여주고 상세페이지 더보기 버튼은 display: none으로 설정
- [x] 상세페이지 버튼이 존재하면 description 맨 밑부분 그라데이션 투명도 설정

## 💻 작업내용
![image](https://user-images.githubusercontent.com/72932126/203095900-7178b64f-ca2d-4372-aa3d-f4bcb4215776.png)



