### PR TITLE
Design/Header/#172

### DIFF
--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -1,137 +1,71 @@
-/* eslint-disable no-unused-vars */
-import React from 'react';
+/* eslint-disable */
+import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import * as S from './style';
 import { AiOutlineUser, AiOutlineShopping } from 'react-icons/ai';
 import { FiLogIn, FiLogOut } from 'react-icons/fi';
 import { GrUserAdmin } from 'react-icons/gr';
 import { Cookies } from 'react-cookie';
+import Swal from 'sweetalert2';
+import withReactContent from 'sweetalert2-react-content';
 
 export const Header = () => {
   const navigate = useNavigate();
+  const swal = withReactContent(Swal);
   const cookies = new Cookies();
   const token = cookies.get('accessToken');
-  const admin = cookies.get('admin');
-  const user = cookies.get('user');
+  const loginUser = cookies.get('loginUser');
   const logout = () => {
-    cookies.remove('accessToken');
-    cookies.remove('refreshToken');
-    cookies.remove('admin');
-    cookies.remove('user');
-    navigate('/');
+    swal
+      .fire({
+        icon: 'question',
+        text: '로그아웃하시겠습니까?',
+        confirmButtonText: '확인',
+        confirmButtonColor: '#289951',
+        showCancelButton: true,
+        cancelButtonText: '취소',
+        width: 400,
+      })
+      .then((result) => {
+        if (result.isConfirmed) {
+          cookies.remove('accessToken');
+          cookies.remove('refreshToken');
+          cookies.remove('loginUser');
+          navigate('/');
+        }
+      });
   };
-
-  if (admin) {
-    return (
-      <>
-        <S.Wrapper>
-          <S.Logo onClick={() => navigate('/')}></S.Logo>
-          <S.Menu>
-            <S.MenuList>
-              <Link to='/itemlist-1'>예방상품리스트</Link>
-            </S.MenuList>
-            <S.MenuList>
-              <Link to='/notice'>공지사항</Link>
-            </S.MenuList>
-            <S.MenuList>
-              <Link to='/qna'>문의하기</Link>
-            </S.MenuList>
-            <S.MenuList>
-              <Link to='/estimate'>견적서 요청</Link>
-            </S.MenuList>
-          </S.Menu>
-          <S.MenuIcons>
-            <S.IconList>
-              <Link to='/admin-member'>
-                <GrUserAdmin />
-              </Link>
-            </S.IconList>
-            <S.IconList>
-              <Link to='/carts'>
-                <AiOutlineShopping />
-              </Link>
-            </S.IconList>
-            <S.IconList>
-              <FiLogOut onClick={logout} />
-            </S.IconList>
-          </S.MenuIcons>
-        </S.Wrapper>
-      </>
-    );
-  } else if (token || user) {
-    return (
-      <>
-        <S.Wrapper>
-          <S.Logo onClick={() => navigate('/')}></S.Logo>
-          <S.Menu>
-            <S.MenuList>
-              <Link to='/itemlist-1'>예방상품리스트</Link>
-            </S.MenuList>
-            <S.MenuList>
-              <Link to='/notice'>공지사항</Link>
-            </S.MenuList>
-            <S.MenuList>
-              <Link to='/qna'>문의하기</Link>
-            </S.MenuList>
-            <S.MenuList>
-              <Link to='/estimate'>견적서 요청</Link>
-            </S.MenuList>
-          </S.Menu>
-          <S.MenuIcons>
-            <S.IconList>
-              <Link to='/mypage'>
-                <AiOutlineUser />
-              </Link>
-            </S.IconList>
-            <S.IconList>
-              <Link to='/carts'>
-                <AiOutlineShopping />
-              </Link>
-            </S.IconList>
-            <S.IconList>
-              <FiLogOut onClick={logout} />
-            </S.IconList>
-          </S.MenuIcons>
-        </S.Wrapper>
-      </>
-    );
-  }
-
   return (
-    <>
-      <S.Wrapper>
-        <S.Logo onClick={() => navigate('/')}></S.Logo>
-        <S.Menu>
-          <S.MenuList>
-            <Link to='/itemlist-1'>예방상품리스트</Link>
-          </S.MenuList>
-          <S.MenuList>
-            <Link to='/notice'>공지사항</Link>
-          </S.MenuList>
-          <S.MenuList>
-            <Link to='/qna'>문의하기</Link>
-          </S.MenuList>
-          <S.MenuList>
-            <Link to='/estimate'>견적서 요청</Link>
-          </S.MenuList>
-        </S.Menu>
-        <S.MenuIcons>
-          {/* <S.IconList>
-            <Link to='/mypage'>
-              <AiOutlineUser />
-            </Link>
-          </S.IconList>
-          <S.IconList>
-            <Link to='/cart'>
-              <AiOutlineShopping />
-            </Link>
-          </S.IconList>
-          <S.IconList>
-            <AiOutlineSearch />
-          </S.IconList> */}
-          <FiLogIn onClick={() => navigate('/sign-in')} style={{ color: '#289951' }} />
-        </S.MenuIcons>
-      </S.Wrapper>
-    </>
+    <S.Container>
+      <S.LogoArea>
+        <S.Logo onClick={() => navigate('/')} />
+      </S.LogoArea>
+      <S.NavArea>
+        <S.Nav onClick={() => navigate('/itemlist-1')}>예방상품리스트</S.Nav>
+        <S.Nav onClick={() => navigate('/notice')}>공지사항</S.Nav>
+        <S.Nav onClick={() => navigate('/qna')}>문의하기</S.Nav>
+        <S.Nav onClick={() => navigate('/estimate')}>견적서 요청</S.Nav>
+      </S.NavArea>
+      <S.UserContentArea>
+        <S.UserContentBox>
+          {loginUser ? (
+            loginUser === 'admin') ? (
+            <S.GreenBtn onClick={() => navigate('/admin-member')}>관리자모드</S.GreenBtn>
+          ) : (
+            <S.IconBox>
+              <AiOutlineUser size='3rem' onClick={() => navigate('/mypage')} style={{ cursor: 'pointer' }} />
+              <AiOutlineShopping size='3rem' onClick={() => navigate('/carts')} style={{ cursor: 'pointer' }} />
+            </S.IconBox>
+          ) : (
+            ''
+          )}
+          {loginUser ? (
+            <S.GrayBtn onClick={() => logout()}>로그아웃</S.GrayBtn>
+          ) : (
+            <S.GreenBtn onClick={() => navigate('/sign-in')}>로그인</S.GreenBtn>
+          )}
+        </S.UserContentBox>
+      </S.UserContentArea>
+    </S.Container>
   );
 };

--- a/src/components/common/Header/style.ts
+++ b/src/components/common/Header/style.ts
@@ -1,59 +1,122 @@
 import styled from 'styled-components';
 
-export const Wrapper = styled.div`
-  /* background-color: pink; */
-  /* width: 100%; */
-  /* min-width: 180rem; */
-  padding: 0 1rem;
+// export const Wrapper = styled.div`
+//   /* background-color: pink; */
+//   /* width: 100%; */
+//   /* min-width: 180rem; */
+//   padding: 0 1rem;
+//   width: 100%;
+//   /* min-width: 130rem; */
+//   height: 8rem;
+//   display: flex;
+//   /* position: fixed;
+//   top: 0; */
+//   background-color: white;
+//   justify-content: space-between;
+//   align-items: center;
+// `;
+// export const Logo = styled.div`
+//   background-image: url(https://user-images.githubusercontent.com/91241596/212526764-a38ae3a1-34e0-4740-b6d0-741a4984431a.png);
+//   margin: 0 0 0 6rem;
+//   width: 15.6rem;
+//   height: 7.6rem;
+//   cursor: pointer;
+// `;
+// export const Menu = styled.ul`
+//   display: flex;
+//   font-size: 2rem;
+//   font-weight: 500;
+//   line-height: 2.4rem;
+//   /* justify-content: center; */
+//   text-align: center;
+//   margin: 0 auto;
+// `;
+// export const MenuList = styled.li`
+//   margin: 0 5rem;
+//   padding: 1rem 1rem;
+// `;
+
+// export const MenuIcons = styled.div`
+//   margin: 0 10rem 0 0;
+//   display: flex;
+//   font-size: 2.4rem;
+
+//   /* position: absolute;
+//   right: 10%; */
+// `;
+// export const IconList = styled.div`
+//   padding: 0 1rem;
+//   /* padding: 1rem 1rem; */
+// `;
+
+// //나중에 로그인버튼 바꿀떄
+// export const SignInBtn = styled.button`
+//   border-radius: 5rem;
+//   border: 0.1rem solid #999999;
+//   font-size: 2rem;
+//   height: 4.8rem;
+//   width: 10rem;
+// `;
+export const Container = styled.div`
   width: 100%;
-  /* min-width: 130rem; */
-  height: 8rem;
+  height: 10rem;
   display: flex;
-  /* position: fixed;
-  top: 0; */
-  background-color: white;
   justify-content: space-between;
   align-items: center;
-`;
-export const Logo = styled.div`
-  background-image: url(https://user-images.githubusercontent.com/91241596/212526764-a38ae3a1-34e0-4740-b6d0-741a4984431a.png);
-  margin: 0 0 0 6rem;
-  width: 15.6rem;
-  height: 7.6rem;
-  cursor: pointer;
-`;
-export const Menu = styled.ul`
-  display: flex;
   font-size: 2rem;
   font-weight: 500;
-  line-height: 2.4rem;
-  /* justify-content: center; */
-  text-align: center;
-  margin: 0 auto;
+  color: #212121;
 `;
-export const MenuList = styled.li`
-  margin: 0 5rem;
-  padding: 1rem 1rem;
+export const LogoArea = styled.div`
+  width: 20%;
+  height: 100%;
+  ${({ theme }) => theme.common.flexCenter};
 `;
-
-export const MenuIcons = styled.div`
-  margin: 0 10rem 0 0;
+export const Logo = styled.img.attrs({ src: 'img/HeaderLogo.png' })`
+  width: 15.6rem;
+  height: 7.5rem;
+  cursor: pointer;
+`;
+export const NavArea = styled.div`
+  width: 60%;
+  height: 100%;
   display: flex;
-  font-size: 2.4rem;
-
-  /* position: absolute;
-  right: 10%; */
+  justify-content: space-evenly;
+  align-items: center;
 `;
-export const IconList = styled.div`
-  padding: 0 1rem;
-  /* padding: 1rem 1rem; */
+export const Nav = styled.div`
+  ${({ theme }) => theme.common.flexCenter};
+  cursor: pointer;
+  padding: 2rem 3rem;
 `;
-
-//나중에 로그인버튼 바꿀떄
-export const SignInBtn = styled.button`
-  border-radius: 5rem;
-  border: 0.1rem solid #999999;
-  font-size: 2rem;
+export const UserContentArea = styled.div`
+  width: 20%;
+  height: 100%;
+  ${({ theme }) => theme.common.flexCenter};
+`;
+export const UserContentBox = styled.div`
+  width: 24rem;
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+`;
+export const IconBox = styled.div`
+  width: 10.4rem;
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+`;
+export const GreenBtn = styled.button`
+  width: 10.4rem;
   height: 4.8rem;
-  width: 10rem;
+  background-color: ${({ theme }) => theme.palette.green};
+  border-radius: 0.5rem;
+  font-size: 2rem;
+  font-weight: 500;
+  color: #ffffff;
+`;
+export const GrayBtn = styled(GreenBtn)`
+  background-color: #ffffff;
+  color: #999999;
+  border: 0.1rem solid #999999;
 `;

--- a/src/components/common/Header/style.ts
+++ b/src/components/common/Header/style.ts
@@ -1,65 +1,8 @@
 import styled from 'styled-components';
 
-// export const Wrapper = styled.div`
-//   /* background-color: pink; */
-//   /* width: 100%; */
-//   /* min-width: 180rem; */
-//   padding: 0 1rem;
-//   width: 100%;
-//   /* min-width: 130rem; */
-//   height: 8rem;
-//   display: flex;
-//   /* position: fixed;
-//   top: 0; */
-//   background-color: white;
-//   justify-content: space-between;
-//   align-items: center;
-// `;
-// export const Logo = styled.div`
-//   background-image: url(https://user-images.githubusercontent.com/91241596/212526764-a38ae3a1-34e0-4740-b6d0-741a4984431a.png);
-//   margin: 0 0 0 6rem;
-//   width: 15.6rem;
-//   height: 7.6rem;
-//   cursor: pointer;
-// `;
-// export const Menu = styled.ul`
-//   display: flex;
-//   font-size: 2rem;
-//   font-weight: 500;
-//   line-height: 2.4rem;
-//   /* justify-content: center; */
-//   text-align: center;
-//   margin: 0 auto;
-// `;
-// export const MenuList = styled.li`
-//   margin: 0 5rem;
-//   padding: 1rem 1rem;
-// `;
-
-// export const MenuIcons = styled.div`
-//   margin: 0 10rem 0 0;
-//   display: flex;
-//   font-size: 2.4rem;
-
-//   /* position: absolute;
-//   right: 10%; */
-// `;
-// export const IconList = styled.div`
-//   padding: 0 1rem;
-//   /* padding: 1rem 1rem; */
-// `;
-
-// //나중에 로그인버튼 바꿀떄
-// export const SignInBtn = styled.button`
-//   border-radius: 5rem;
-//   border: 0.1rem solid #999999;
-//   font-size: 2rem;
-//   height: 4.8rem;
-//   width: 10rem;
-// `;
 export const Container = styled.div`
   width: 100%;
-  height: 10rem;
+  height: 8.5rem;
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/src/components/common/hooks/Refresh.tsx
+++ b/src/components/common/hooks/Refresh.tsx
@@ -10,15 +10,12 @@ export const Refresh = () => {
     async function (config: any) {
       const accessToken = cookie.get('accessToken');
       const refreshToken = cookie.get('refreshToken');
-      console.log('인터셉트');
       if (!accessToken && refreshToken) {
         //엑세트토큰 쿠키만료시간
         const tokenExpires = new Date();
-        // tokenExpires.setMinutes(tokenExpires.getMinutes() + 180);
         tokenExpires.setMinutes(tokenExpires.getMinutes() + 1);
         //리프레시토큰 쿠키만료시간
         const rtokenExpires = new Date();
-        // rtokenExpires.setMinutes(tokenExpires.getMinutes() + 360);
         rtokenExpires.setMinutes(tokenExpires.getMinutes() + 5);
         await fetch(`${process.env.REACT_APP_API_URL}/refresh`, {
           headers: {
@@ -40,7 +37,6 @@ export const Refresh = () => {
             } else if (data === 'ROLE_USER') {
               setCookie('loginUser', 'user', { path: '/', expires: tokenExpires });
             }
-            console.log(cookie.get('accessToken'));
           });
       }
       return config;

--- a/src/components/common/hooks/Refresh.tsx
+++ b/src/components/common/hooks/Refresh.tsx
@@ -4,7 +4,7 @@ import { useCookies, Cookies } from 'react-cookie';
 
 export const Refresh = () => {
   const cookie = new Cookies();
-  const [cookies, setCookie, removeCookie] = useCookies();
+  const [, setCookie] = useCookies();
 
   axios.interceptors.request.use(
     async function (config: any) {

--- a/src/components/main/MainBanner/index.tsx
+++ b/src/components/main/MainBanner/index.tsx
@@ -13,6 +13,8 @@ export const MainBanner = () => {
     slidesToScroll: 1,
     useTransform: false,
     arrows: false,
+    pauseOnHover: false,
+    pauseOnFocus: false,
     afterChange: () => {
       setSlide(true);
     },

--- a/src/components/main/NoticeBar/index.tsx
+++ b/src/components/main/NoticeBar/index.tsx
@@ -50,22 +50,24 @@ export const NoticeBar = () => {
       <S.NoticeContent>
         <S.LeftTextArea>
           <S.LeftText>공지사항</S.LeftText>
+          <S.LeftBar />
         </S.LeftTextArea>
-        <S.LeftBar />
         <S.TitleArea>
           <S.Title onClick={() => moveDetail(noticeList[count].id)}>
             {noticeList[count]?.title}
           </S.Title>
         </S.TitleArea>
-        <S.ArrowBox>
-          <S.ArrowArea onClick={() => preNotice()}>
-            <AiOutlineLeft color='#ffffff' />
-          </S.ArrowArea>
-          <S.ArrowBar />
-          <S.ArrowArea onClick={() => nextNotice()}>
-            <AiOutlineRight color='#ffffff' />
-          </S.ArrowArea>
-        </S.ArrowBox>
+        <S.ArrowArea>
+          <S.ArrowBox>
+            <S.ArrowIcon onClick={() => preNotice()}>
+              <AiOutlineLeft color='#ffffff' />
+            </S.ArrowIcon>
+            <S.ArrowBar />
+            <S.ArrowIcon onClick={() => nextNotice()}>
+              <AiOutlineRight color='#ffffff' />
+            </S.ArrowIcon>
+          </S.ArrowBox>
+        </S.ArrowArea>
       </S.NoticeContent>
     </S.NoticeBarWrap>
   );

--- a/src/components/main/NoticeBar/style.ts
+++ b/src/components/main/NoticeBar/style.ts
@@ -11,7 +11,7 @@ export const NoticeBarWrap = styled.div`
   font-size: 2.4rem;
   font-weight: 500;
   color: #ffffff;
-  border-top: 1px solid #ffffff;
+  border-top: 0.05rem solid #ffffff;
 `;
 export const NoticeContent = styled.div`
   width: 100%;
@@ -20,18 +20,23 @@ export const NoticeContent = styled.div`
   align-items: center;
 `;
 export const LeftTextArea = styled.div`
-  width: 43.8rem;
+  /* width: 43.8rem; */
+  width: 20%;
   height: 100%;
   ${({ theme }) => theme.common.flexCenter};
+  position: relative;
 `;
 export const LeftText = styled.span``;
 export const LeftBar = styled.div`
   width: 0.2rem;
   height: 4rem;
   background-color: #ffffff;
+  position: absolute;
+  right: 0;
 `;
 export const TitleArea = styled.div`
-  width: 100rem;
+  /* width: 100rem; */
+  width: 60%;
   height: 100%;
   ${({ theme }) => theme.common.flexCenter};
 `;
@@ -41,11 +46,19 @@ export const Title = styled.span`
     text-decoration: underline;
   }
 `;
+export const ArrowArea = styled.div`
+  width: 20%;
+  display: flex;
+  align-items: center;
+  position: relative;
+`;
 export const ArrowBox = styled.div`
   display: flex;
   align-items: center;
+  position: absolute;
+  right: 25rem;
 `;
-export const ArrowArea = styled.div`
+export const ArrowIcon = styled.div`
   cursor: pointer;
   display: flex;
   align-items: center;

--- a/src/components/main/ViewedItem/index.tsx
+++ b/src/components/main/ViewedItem/index.tsx
@@ -2,10 +2,12 @@ import React, { useRef, useState } from 'react';
 import * as S from './style';
 import { AiOutlineLeft, AiOutlineRight } from 'react-icons/ai';
 import { useNavigate } from 'react-router-dom';
+import { AiOutlineClose } from 'react-icons/ai';
 
 export const ViewedItem = () => {
   const [count, setCount] = useState(1);
   const [idx, setIdx] = useState([0, 1, 2]);
+  const [close, setClose] = useState(false);
   const navigate = useNavigate();
   const getString: any = localStorage.getItem('viewedItems');
   const viewedItems = useRef<any>(getString ? JSON.parse(getString) : []);
@@ -47,9 +49,12 @@ export const ViewedItem = () => {
   };
 
   return (
-    <S.Container style={{ display: viewedItems.current.length === 0 ? 'none' : '' }}>
+    <S.Container style={{ display: viewedItems.current.length === 0 || close ? 'none' : '' }}>
       <S.TitleArea>
         <S.Title>내가 본 상품</S.Title>
+        <S.closeBtnArea onClick={() => setClose(true)}>
+          <AiOutlineClose size='2rem' />
+        </S.closeBtnArea>
       </S.TitleArea>
       <S.ItemArea>
         {viewedItems.current[idx[0]] ? (
@@ -92,13 +97,13 @@ export const ViewedItem = () => {
       </S.ItemArea>
       <S.PageArea>
         <S.ArrowBox>
-          <AiOutlineLeft size='2.4rem' color='#ffffff' onClick={() => countMinus()} />
+          <AiOutlineLeft size='2rem' color='#ffffff' onClick={() => countMinus()} />
         </S.ArrowBox>
         <S.PageText>
           {count} / {totalPage.current}
         </S.PageText>
         <S.ArrowBox>
-          <AiOutlineRight size='2.4rem' color='#ffffff' onClick={() => countPlus()} />
+          <AiOutlineRight size='2rem' color='#ffffff' onClick={() => countPlus()} />
         </S.ArrowBox>
       </S.PageArea>
     </S.Container>

--- a/src/components/main/ViewedItem/index.tsx
+++ b/src/components/main/ViewedItem/index.tsx
@@ -92,13 +92,13 @@ export const ViewedItem = () => {
       </S.ItemArea>
       <S.PageArea>
         <S.ArrowBox>
-          <AiOutlineLeft size={24} color='#ffffff' onClick={() => countMinus()} />
+          <AiOutlineLeft size='2.4rem' color='#ffffff' onClick={() => countMinus()} />
         </S.ArrowBox>
         <S.PageText>
           {count} / {totalPage.current}
         </S.PageText>
         <S.ArrowBox>
-          <AiOutlineRight size={24} color='#ffffff' onClick={() => countPlus()} />
+          <AiOutlineRight size='2.4rem' color='#ffffff' onClick={() => countPlus()} />
         </S.ArrowBox>
       </S.PageArea>
     </S.Container>

--- a/src/components/main/ViewedItem/style.ts
+++ b/src/components/main/ViewedItem/style.ts
@@ -12,6 +12,9 @@ export const Container = styled.div`
   border-radius: 5px 0px 0px 5px;
   box-shadow: 2px 4px 12px 4px rgba(0, 0, 0, 0.25);
   border: 0.1rem solid ${({ theme }) => theme.palette.green};
+  @media (max-width: 1919px) {
+    display: none;
+  }
 `;
 export const TitleArea = styled.div`
   ${({ theme }) => theme.common.flexCenter};

--- a/src/components/main/ViewedItem/style.ts
+++ b/src/components/main/ViewedItem/style.ts
@@ -4,7 +4,8 @@ export const Container = styled.div`
   position: fixed;
   top: 15%;
   right: 0;
-  width: 22.4rem;
+  /* width: 22.4rem; */
+  width: 17rem;
   background-color: #fbfbfb;
   z-index: 100;
   display: flex;
@@ -12,24 +13,33 @@ export const Container = styled.div`
   border-radius: 5px 0px 0px 5px;
   box-shadow: 2px 4px 12px 4px rgba(0, 0, 0, 0.25);
   border: 0.1rem solid ${({ theme }) => theme.palette.green};
-  @media (max-width: 1919px) {
+  /* @media (max-width: 1919px) {
     display: none;
-  }
+  } */
+  opacity: 0.85;
 `;
 export const TitleArea = styled.div`
   ${({ theme }) => theme.common.flexCenter};
   width: 100%;
-  height: 4.8rem;
+  height: 4rem;
+  position: relative;
+`;
+export const closeBtnArea = styled.div`
+  ${({ theme }) => theme.common.flexCenter};
+  position: absolute;
+  right: 1rem;
+  cursor: pointer;
 `;
 export const Title = styled.span`
-  font-size: 2rem;
+  font-size: 1.8rem;
   font-weight: 500;
   color: #212121;
 `;
 export const ItemArea = styled.div`
   ${({ theme }) => theme.common.flexCenter};
   width: 100%;
-  height: 21.6rem;
+  /* height: 21.6rem; */
+  height: 17rem;
   border-top: 0.1rem solid #9d9d9d;
 `;
 export const ItemContent = styled.div`
@@ -38,19 +48,21 @@ export const ItemContent = styled.div`
   cursor: pointer;
 `;
 export const ItemImg = styled.img`
-  width: 15.5rem;
-  height: 15.5rem;
+  /* width: 15.5rem;
+  height: 15.5rem; */
+  width: 13rem;
+  height: 13rem;
   border: 0.1rem solid #dddddd;
 `;
 export const ItemName = styled.span`
-  font-size: 1.6rem;
+  font-size: 1.5rem;
   font-weight: 400;
   color: #999999;
-  margin-top: 1.6rem;
+  margin-top: 1rem;
 `;
 export const PageArea = styled.div`
   width: 100%;
-  height: 4.8rem;
+  height: 4rem;
   background-color: ${({ theme }) => theme.palette.green};
   display: flex;
   justify-content: space-between;
@@ -63,7 +75,7 @@ export const ArrowBox = styled.div`
 `;
 export const PageText = styled.div`
   ${({ theme }) => theme.common.flexCenter};
-  font-size: 1.6rem;
+  font-size: 1.4rem;
   font-weight: 400;
   color: #ffffff;
 `;

--- a/src/pages/SignIn/index.tsx
+++ b/src/pages/SignIn/index.tsx
@@ -10,7 +10,7 @@ import { Header } from '../../components/common/Header';
 
 export const SignIn = () => {
   const navigate = useNavigate();
-  const [cookies, setCookie, removeCookie] = useCookies();
+  const [, setCookie] = useCookies();
   const cookie = new Cookies();
   const [saveIdChecked, setSaveIdChecked] = useState(cookie.get('savedId') ? true : false);
   const savedId = useRef(cookie.get('savedId'));

--- a/src/pages/SignIn/index.tsx
+++ b/src/pages/SignIn/index.tsx
@@ -5,12 +5,15 @@ import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import { useCookies, Cookies } from 'react-cookie';
 import { Header } from '../../components/common/Header';
+import Swal from 'sweetalert2';
+import withReactContent from 'sweetalert2-react-content';
 // import { Footer } from '../../components/common/Footer';
 // import { FindId } from '../../components/FindId';
 
 export const SignIn = () => {
   const navigate = useNavigate();
   const [, setCookie] = useCookies();
+  const swal = withReactContent(Swal);
   const cookie = new Cookies();
   const [saveIdChecked, setSaveIdChecked] = useState(cookie.get('savedId') ? true : false);
   const savedId = useRef(cookie.get('savedId'));
@@ -76,11 +79,31 @@ export const SignIn = () => {
             navigate('/');
           }
         });
-    } catch (e: any) {
-      if (e.response.data.code === 1400) {
-        alert('일치하는 회원정보가 없습니다.');
+    } catch (err: any) {
+      if (err.response.data.code === 1400) {
+        swal.fire({
+          icon: 'info',
+          text: '일치하는 회원정보가 없습니다.',
+          confirmButtonText: '확인',
+          confirmButtonColor: '#289951',
+          width: 400,
+        });
+      } else if (err.response.data.code === 1401) {
+        swal.fire({
+          icon: 'info',
+          text: '휴면계정입니다.',
+          confirmButtonText: '확인',
+          confirmButtonColor: '#289951',
+          width: 400,
+        });
       } else {
-        alert(e.response.data.message);
+        swal.fire({
+          icon: 'warning',
+          text: err.response.data.message,
+          confirmButtonText: '확인',
+          confirmButtonColor: '#289951',
+          width: 400,
+        });
       }
     }
   };

--- a/src/pages/SignIn/index.tsx
+++ b/src/pages/SignIn/index.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-unused-vars */
-import React, { useEffect, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import * as S from './style';
 import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
@@ -7,25 +7,20 @@ import { useCookies, Cookies } from 'react-cookie';
 import { Header } from '../../components/common/Header';
 // import { Footer } from '../../components/common/Footer';
 // import { FindId } from '../../components/FindId';
-// import { Refresh } from '../../components/common/hooks/refresh';
 
 export const SignIn = () => {
-  const [cookies, setCookie, removeCookie] = useCookies();
-  // const cookie = new Cookies();
-  // const refreshToken = cookie.get('refreshToken');
-  // Refresh();
-  //엑세트토큰 쿠키만료시간
-  const tokenExpires = new Date();
-  // tokenExpires.setMinutes(tokenExpires.getMinutes() + 180);
-  tokenExpires.setMinutes(tokenExpires.getMinutes() + 1);
-  //리프레시토큰 쿠키만료시간
-  const rtokenExpires = new Date();
-  // rtokenExpires.setMinutes(tokenExpires.getMinutes() + 360);
-  rtokenExpires.setMinutes(tokenExpires.getMinutes() + 5);
-
   const navigate = useNavigate();
+  const [cookies, setCookie, removeCookie] = useCookies();
+  const cookie = new Cookies();
+  const [saveIdChecked, setSaveIdChecked] = useState(cookie.get('savedId') ? true : false);
+  const savedId = useRef(cookie.get('savedId'));
+  const onChangeSaveId = () => {
+    setSaveIdChecked(!saveIdChecked);
+  };
+  // const refreshToken = cookie.get('refreshToken');
+
   //id, password
-  const [id, setId] = useState('');
+  const [id, setId] = useState(cookie.get('savedId') ? cookie.get('savedId') : '');
   const [pw, setPw] = useState('');
 
   //아이디 입력
@@ -38,6 +33,14 @@ export const SignIn = () => {
   };
   //로그인
   const signIn = async () => {
+    //엑세트토큰 쿠키만료시간
+    const tokenExpires = new Date();
+    // tokenExpires.setMinutes(tokenExpires.getMinutes() + 180);
+    tokenExpires.setMinutes(tokenExpires.getMinutes() + 1);
+    //리프레시토큰 쿠키만료시간
+    const rtokenExpires = new Date();
+    // rtokenExpires.setMinutes(tokenExpires.getMinutes() + 360);
+    rtokenExpires.setMinutes(tokenExpires.getMinutes() + 5);
     try {
       await axios
         .post(
@@ -61,6 +64,15 @@ export const SignIn = () => {
             } else if (res.data === 'ROLE_USER') {
               setCookie('loginUser', 'user', { path: '/', expires: tokenExpires });
             }
+            if (saveIdChecked) {
+              if (savedId.current !== id) {
+                setCookie('savedId', id, { path: '/', maxAge: 60 * 60 * 24 * 180 });
+              }
+            } else {
+              if (savedId.current) {
+                cookie.remove('savedId');
+              }
+            }
             navigate('/');
           }
         });
@@ -73,137 +85,38 @@ export const SignIn = () => {
     }
   };
 
-  // const create = axios.create({
-  //   baseURL: `${process.env.REACT_APP_BASE_URL}`,
-  //   headers: {
-  //     'Content-Type': 'application/json',
-  //     Authorization: token,
-  //   },
-  // });
-
   //회원가입
   const navigateSignUp = () => {
     navigate('/sign-up1');
   };
 
   //아이디저장
-  const [saveId, setSaveId] = useState(false);
-  useEffect(() => {
-    if (cookies.idSaved !== undefined) {
-      setId(cookies.idSaved);
-      setSaveId(true);
-    }
-  }, []);
+  // const [saveId, setSaveId] = useState(false);
+  // useEffect(() => {
+  //   if (cookies.idSaved !== undefined) {
+  //     setId(cookies.idSaved);
+  //     setSaveId(true);
+  //   }
+  // }, []);
 
-  const onIdChange = (e: any) => {
-    setSaveId(e.target.checked);
-    if (e.target.checked) {
-      // 아이디 저장 유효기간은 6달
-      setCookie('idSaved', id, { maxAge: 60 * 60 * 24 * 180 });
-    } else {
-      removeCookie('idSaved');
-    }
-  };
+  // const onIdChange = (e: any) => {
+  //   setSaveId(e.target.checked);
+  //   if (e.target.checked) {
+  //     // 아이디 저장 유효기간은 6달
+  //     setCookie('idSaved', id, { maxAge: 60 * 60 * 24 * 180 });
+  //   } else {
+  //     removeCookie('idSaved');
+  //   }
+  // };
   //아이디 비밀번호 찾기 모달창
   // const [isOpen, setIsOpen] = useState<boolean>(false);
   // const onOpen = () => {
   //   setIsOpen(!isOpen);
   // };
 
-  // const refresh = async () => {
-  //   if (!jwt && refreshToken) {
-  //     await axios({
-  //       method: 'get',
-  //       url: `${process.env.REACT_APP_API_URL}/refresh`,
-  //       headers: {
-  //         'refresh-token': refreshToken,
-  //       },
-  //     }).then((res) => {
-  //       const token = res.headers.authorization;
-  //       const rtoken = res.headers['refresh-token'];
-  //       setCookie('accessToken', token, { path: '/', expires: tokenExpires });
-  //       setCookie('refreshToken', rtoken, { path: '/', expires: rtokenExpires });
-  //       if (res.data === 'ROLE_ADMIN') {
-  //         setCookie('loginUser', 'admin', { path: '/', expires: tokenExpires });
-  //       } else if (res.data === 'ROLE_USER') {
-  //         setCookie('loginUser', 'user', { path: '/', expires: tokenExpires });
-  //       }
-  //     });
-  //   }
-  // };
-
-  // const refresh = async () => {
-  //   await axios({
-  //     method: 'get',
-  //     url: `${process.env.REACT_APP_API_URL}/refresh`,
-  //     headers: {
-  //       'refresh-token': refreshToken,
-  //     },
-  //   }).then((res) => {
-  //     const token = res.headers.authorization;
-  //     const rtoken = res.headers['refresh-token'];
-  //     setCookie('accessToken', token, { path: '/', expires: tokenExpires });
-  //     setCookie('refreshToken', rtoken, { path: '/', expires: rtokenExpires });
-  //     if (res.data === 'ROLE_ADMIN') {
-  //       setCookie('loginUser', 'admin', { path: '/', expires: tokenExpires });
-  //     } else if (res.data === 'ROLE_USER') {
-  //       setCookie('loginUser', 'user', { path: '/', expires: tokenExpires });
-  //     }
-  //   });
-  // };
-
-  // axios.interceptors.request.use(
-  //   function (config: any) {
-  //     const accessToken = cookie.get('accessToken');
-  //     const refreshToken = cookie.get('refreshToken');
-  //     if (!accessToken && refreshToken) {
-  //       console.log('엑세스토큰만료');
-  //       axios({
-  //         method: 'get',
-  //         url: `${process.env.REACT_APP_API_URL}/refresh`,
-  //         headers: {
-  //           'refresh-token': refreshToken,
-  //         },
-  //       }).then((res) => {
-  //         const token = res.headers.authorization;
-  //         const rtoken = res.headers['refresh-token'];
-  //         setCookie('accessToken', token, { path: '/', expires: tokenExpires });
-  //         setCookie('refreshToken', rtoken, { path: '/', expires: rtokenExpires });
-  //         if (res.data === 'ROLE_ADMIN') {
-  //           setCookie('loginUser', 'admin', { path: '/', expires: tokenExpires });
-  //         } else if (res.data === 'ROLE_USER') {
-  //           setCookie('loginUser', 'user', { path: '/', expires: tokenExpires });
-  //         }
-  //         console.log('hi');
-  //       });
-  //     }
-  //     return config;
-  //   },
-  //   function (error) {
-  //     return Promise.reject(error);
-  //   },
-  // );
-
-  // axios.interceptors.request.use(
-  //   function (config: any) {
-  //     const accessToken = cookie.get('accessToken');
-  //     const refreshToken = cookie.get('refreshToken');
-  //     if (!accessToken && refreshToken) {
-  //       config.headers.common['Authorization'] = `${accessToken}`;
-  //       config.headers.common['Refresh-Token'] = `${refreshToken}`;
-  //       console.log('hi');
-  //     }
-  //     return config;
-  //   },
-  //   function (error) {
-  //     return Promise.reject(error);
-  //   },
-  // );
-
   return (
     <>
       <Header />
-      {/* <button onClick={() => refresh()}>test</button> */}
       <S.Container>
         <S.Wrapper>
           <S.InputContainer>
@@ -233,7 +146,11 @@ export const SignIn = () => {
           <S.SignText>
             <S.IdCheck>
               <label>
-                <S.IdCheckInput type='checkbox' onChange={onIdChange} checked={saveId} />
+                <S.IdCheckInput
+                  type='checkbox'
+                  checked={saveIdChecked}
+                  onChange={() => onChangeSaveId()}
+                />
                 ID 저장하기
               </label>
             </S.IdCheck>


### PR DESCRIPTION
## ⭐ 개요
Header

## 📋 작업사항
- [x] header 레이아웃 잡기
- [x] login실패 시 알림창
- [x] login상태 logout상태
- [x] admin인지 user인지 판별
- [x] logout알림창
- [x] 아이디저장기능 개선 [체크상태로 로그인시에 쿠키에 저장(6개월), 체크해제 후 로그인하면 저장했던 기록이사라진다. 체크는 활성화 되어있고 아이디 값이 바뀌면 쿠키 만료기한 다시 갱신(6개월), 기존값과 같을 경우 쿠키 만료기한이 갱신되지않는다. ]
- [x] 메인페이지 배너 mouseOver시에 멈추는기능 없앰
- [x] 메인페이지 공지사항 레이아웃 잡기
- [x] 내가본상품 전체적인 사이즈 축소 및 투명도 설정
- [x] 내가본상품 닫기 버튼 추가

## 😉 전달사항
사진은 오른쪽이 살짝 잘려서 나오네요

## 💻 작업내용

![image](https://user-images.githubusercontent.com/72932126/218251139-38ae0b8e-b4a5-49a3-806d-2e94709c86a2.png)



