### PR TITLE
feat/Header/#204

### DIFF
--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -1,10 +1,8 @@
 /* eslint-disable */
 import React, { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import * as S from './style';
 import { AiOutlineUser, AiOutlineShopping } from 'react-icons/ai';
-import { FiLogIn, FiLogOut } from 'react-icons/fi';
-import { GrUserAdmin } from 'react-icons/gr';
 import { Cookies } from 'react-cookie';
 import Swal from 'sweetalert2';
 import withReactContent from 'sweetalert2-react-content';
@@ -13,8 +11,17 @@ export const Header = () => {
   const navigate = useNavigate();
   const swal = withReactContent(Swal);
   const cookies = new Cookies();
-  const token = cookies.get('accessToken');
   const loginUser = cookies.get('loginUser');
+  const location = useLocation();
+
+  const moveLocation = (path: string) => {
+    if (path === location.pathname) {
+      window.location.reload();
+    } else {
+      navigate(path);
+    }
+  };
+
   const logout = () => {
     swal
       .fire({
@@ -31,30 +38,30 @@ export const Header = () => {
           cookies.remove('accessToken');
           cookies.remove('refreshToken');
           cookies.remove('loginUser');
-          navigate('/');
+          moveLocation('/');
         }
       });
   };
   return (
     <S.Container>
       <S.LogoArea>
-        <S.Logo onClick={() => navigate('/')} />
+        <S.Logo onClick={() => moveLocation('/')} />
       </S.LogoArea>
       <S.NavArea>
-        <S.Nav onClick={() => navigate('/itemlist-1')}>예방상품리스트</S.Nav>
-        <S.Nav onClick={() => navigate('/notice')}>공지사항</S.Nav>
-        <S.Nav onClick={() => navigate('/qna')}>문의하기</S.Nav>
-        <S.Nav onClick={() => navigate('/estimate')}>견적서 요청</S.Nav>
+        <S.Nav onClick={() => moveLocation('/itemlist-1')}>예방상품리스트</S.Nav>
+        <S.Nav onClick={() => moveLocation('/notice')}>공지사항</S.Nav>
+        <S.Nav onClick={() => moveLocation('/qna')}>문의하기</S.Nav>
+        <S.Nav onClick={() => moveLocation('/estimate')}>견적서 요청</S.Nav>
       </S.NavArea>
       <S.UserContentArea>
         <S.UserContentBox>
           {loginUser ? (
             loginUser === 'admin') ? (
-            <S.GreenBtn onClick={() => navigate('/admin-member')}>관리자모드</S.GreenBtn>
+            <S.GreenBtn onClick={() => moveLocation('/admin-member')}>관리자모드</S.GreenBtn>
           ) : (
             <S.IconBox>
-              <AiOutlineUser size='3rem' onClick={() => navigate('/mypage')} style={{ cursor: 'pointer' }} />
-              <AiOutlineShopping size='3rem' onClick={() => navigate('/carts')} style={{ cursor: 'pointer' }} />
+              <AiOutlineUser size='3rem' onClick={() => moveLocation('/mypage')} style={{ cursor: 'pointer' }} />
+              <AiOutlineShopping size='3rem' onClick={() => moveLocation('/carts')} style={{ cursor: 'pointer' }} />
             </S.IconBox>
           ) : (
             ''

--- a/src/components/common/hooks/Refresh.tsx
+++ b/src/components/common/hooks/Refresh.tsx
@@ -13,10 +13,10 @@ export const Refresh = () => {
       if (!accessToken && refreshToken) {
         //엑세트토큰 쿠키만료시간
         const tokenExpires = new Date();
-        tokenExpires.setMinutes(tokenExpires.getMinutes() + 1);
+        tokenExpires.setMinutes(tokenExpires.getMinutes() + 10);
         //리프레시토큰 쿠키만료시간
         const rtokenExpires = new Date();
-        rtokenExpires.setMinutes(tokenExpires.getMinutes() + 5);
+        rtokenExpires.setMinutes(tokenExpires.getMinutes() + 60);
         await fetch(`${process.env.REACT_APP_API_URL}/refresh`, {
           headers: {
             'refresh-token': refreshToken,

--- a/src/components/item/Nav/index.tsx
+++ b/src/components/item/Nav/index.tsx
@@ -1,15 +1,17 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import * as S from './style';
 
 export const Nav = (props: any) => {
   const navigate = useNavigate();
   const categoryList = props.categoryList;
   let selectNav = props.selectNav;
-  const location = window.location.pathname;
-  const onChangeNav = (url: string) => {
-    if (location !== url) {
-      navigate(url);
+  const location = useLocation();
+  const onChangeNav = (path: string) => {
+    if (location.pathname === path) {
+      window.location.reload();
+    } else {
+      navigate(path);
     }
   };
   return (

--- a/src/components/shopping/CartsList/index.tsx
+++ b/src/components/shopping/CartsList/index.tsx
@@ -115,26 +115,30 @@ export const CartsList = (props: any) => {
 
   //선택 아이템 삭제
   const deleteSelectItem = async () => {
-    let items = checkedList.map((item: any) => 'itemId=' + item.id + '&');
-    let itemsString = items.join('');
-    await axios({
-      method: 'delete',
-      url: `${process.env.REACT_APP_API_URL}/user/cartItem?${itemsString}`,
-      headers: {
-        Authorization: jwt,
-      },
-    });
-    await axios({
-      method: 'get',
-      url: `${process.env.REACT_APP_API_URL}/user/cart`,
-      headers: {
-        Authorization: jwt,
-      },
-    }).then((res) => {
-      setData(res.data.content);
-      setCountList(res.data.content.map((el: any) => el.itemQuantity));
-      setCheckedList([]);
-    });
+    if (!cookies.get('refreshToken')) {
+      navigate('/sign-in');
+    } else {
+      let items = checkedList.map((item: any) => 'itemId=' + item.id + '&');
+      let itemsString = items.join('');
+      await axios({
+        method: 'delete',
+        url: `${process.env.REACT_APP_API_URL}/user/cartItem?${itemsString}`,
+        headers: {
+          Authorization: jwt,
+        },
+      });
+      await axios({
+        method: 'get',
+        url: `${process.env.REACT_APP_API_URL}/user/cart`,
+        headers: {
+          Authorization: jwt,
+        },
+      }).then((res) => {
+        setData(res.data.content);
+        setCountList(res.data.content.map((el: any) => el.itemQuantity));
+        setCheckedList([]);
+      });
+    }
   };
 
   useEffect(() => {

--- a/src/components/shopping/PaymentInfo/index.tsx
+++ b/src/components/shopping/PaymentInfo/index.tsx
@@ -200,7 +200,7 @@ export const PaymentInfo = (props: any) => {
           </S.PayBtn>
         </S.PaymentSelectArea>
         <S.PaymentDesArea>
-          <S.PaymentDes>- 신용카드 할부는 100,000원 이상일 경우에만 가능합니다.</S.PaymentDes>
+          <S.PaymentDes>- 신용카드 할부는 50,000원 이상일 경우에만 가능합니다.</S.PaymentDes>
           {/* <S.PaymentDes>
             - 가상계좌 발급 시, 12시간 이내에 입금완료해주셔야 배송이 진행됩니다.
           </S.PaymentDes> */}
@@ -208,9 +208,9 @@ export const PaymentInfo = (props: any) => {
             - 정확한 결제와 주문완료를 위하여 주문완료 페이지가 보여지기 전에 현재창과 결제창을
             닫지마십시오.
           </S.PaymentDes>
-          {/* <S.PaymentDes>
-            - 세금계산서 발행을 원하실 경우, 고객센터 &gt; 문의하기에서 신청해주시기 바랍니다.
-          </S.PaymentDes> */}
+          <S.PaymentDes>
+            - 결제창을 열고 30분 안에 결제를 진행해주세요. 30분 경과 시 자동으로 메인페이지로 이동됩니다.
+          </S.PaymentDes>
         </S.PaymentDesArea>
       </S.PaymentContainer>
     </S.Container>

--- a/src/pages/Carts/index.tsx
+++ b/src/pages/Carts/index.tsx
@@ -20,7 +20,6 @@ export const Carts = () => {
   const [resultList, setResultList] = useState<any>('');
   const [data, setData] = useState<any>('');
   const cookies = new Cookies();
-  const jwt = cookies.get('accessToken');
 
   //선택상품구매
   const selectPurchase = () => {
@@ -73,7 +72,7 @@ export const Carts = () => {
         method: 'get',
         url: `${process.env.REACT_APP_API_URL}/user/cart?page=0&size=20`,
         headers: {
-          Authorization: jwt,
+          Authorization: cookies.get('accessToken'),
         },
       }).then((res) => {
         length = res.data.content.length;
@@ -119,7 +118,7 @@ export const Carts = () => {
           method: 'get',
           url: `${process.env.REACT_APP_API_URL}/user/cart?page=0&size=20`,
           headers: {
-            Authorization: jwt,
+            Authorization: cookies.get('accessToken'),
           },
         }).then((res) => {
           setData(res.data.content);
@@ -140,7 +139,8 @@ export const Carts = () => {
       }
     };
     getData();
-  }, [jwt, navigate]);
+    // eslint-disable-next-line
+  }, [navigate]);
   const itemInCart =
     data.length === 0 ? (
       <S.Container>

--- a/src/pages/MyPage/MyPageWd/index.tsx
+++ b/src/pages/MyPage/MyPageWd/index.tsx
@@ -22,6 +22,12 @@ export const MyPageWd = () => {
   const [password, setPassword] = useState('');
   const [passwordCheck, setPasswordCheck] = useState(false);
 
+  useEffect(() => {
+    if (!cookies.get('refreshToken')) {
+      navigate('/sign-in');
+    }
+  });
+
   const onChangeId = (e: string) => {
     setId(e);
     validationId(e);
@@ -55,50 +61,54 @@ export const MyPageWd = () => {
   }, [idCheck, passwordCheck]);
 
   const deleteEvent = () => {
-    swal
-      .fire({
-        icon: 'question',
-        text: '회원 탈퇴하시겠습니까?',
-        confirmButtonText: '확인',
-        confirmButtonColor: '#289951',
-        showCancelButton: true,
-        cancelButtonText: '취소',
-        width: 400,
-      })
-      .then(async (result) => {
-        if (result.isConfirmed) {
-          try {
-            await axios({
-              method: 'post',
-              url: `${process.env.REACT_APP_API_URL}/user/withdrawal`,
-              headers: {
-                Authorization: cookies.get('accessToken'),
-              },
-              data: {
-                inputUsername: id,
-                password: password,
-              },
-            }).then((res) => {
+    if (!cookies.get('refreshToken')) {
+      navigate('/sign-in');
+    } else {
+      swal
+        .fire({
+          icon: 'question',
+          text: '회원 탈퇴하시겠습니까?',
+          confirmButtonText: '확인',
+          confirmButtonColor: '#289951',
+          showCancelButton: true,
+          cancelButtonText: '취소',
+          width: 400,
+        })
+        .then(async (result) => {
+          if (result.isConfirmed) {
+            try {
+              await axios({
+                method: 'post',
+                url: `${process.env.REACT_APP_API_URL}/user/withdrawal`,
+                headers: {
+                  Authorization: cookies.get('accessToken'),
+                },
+                data: {
+                  inputUsername: id,
+                  password: password,
+                },
+              }).then((res) => {
+                swal.fire({
+                  icon: 'success',
+                  text: '탈퇴 완료되었습니다.',
+                  confirmButtonText: '확인',
+                  confirmButtonColor: '#289951',
+                  width: 400,
+                });
+                navigate('/');
+              });
+            } catch (err: any) {
               swal.fire({
-                icon: 'success',
-                text: '탈퇴 완료되었습니다.',
+                icon: 'warning',
+                text: err.response.data.message,
                 confirmButtonText: '확인',
                 confirmButtonColor: '#289951',
                 width: 400,
               });
-              navigate('/');
-            });
-          } catch (err: any) {
-            swal.fire({
-              icon: 'warning',
-              text: err.response.data.message,
-              confirmButtonText: '확인',
-              confirmButtonColor: '#289951',
-              width: 400,
-            });
+            }
           }
-        }
-      });
+        });
+    }
   };
 
   return (
@@ -119,7 +129,7 @@ export const MyPageWd = () => {
             <WithdrawInfo2 />
           </S.AreaWrap>
           <S.AreaWrap>
-            <S.Mid>탈퇴사유</S.Mid>
+            <S.Mid>회원정보</S.Mid>
             <S.InputWrapper>
               <div>
                 <label>아이디</label>

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -284,59 +284,63 @@ export const MyPage = () => {
   ]);
 
   const changeUserData = async () => {
-    swal
-      .fire({
-        icon: 'question',
-        text: '회원정보를 수정하시겠습니까?',
-        confirmButtonText: '확인',
-        confirmButtonColor: '#289951',
-        showCancelButton: true,
-        cancelButtonText: '취소',
-        width: 400,
-      })
-      .then(async (result) => {
-        if (result.isConfirmed) {
-          try {
-            await axios({
-              method: 'PUT',
-              url: `${process.env.REACT_APP_API_URL}/user/update`,
-              headers: {
-                Authorization: cookies.get('accessToken'),
-              },
-              data: {
-                name: name,
-                birth: birth,
-                representativeName: ceo,
-                phoneNumber: phone,
-                companyRegistrationNumber: saupja,
-                corporateRegistrationNumber: beobin,
-                zipcode: zip,
-                basicAddress: basic,
-                detailedAddress: detail,
-              },
-            }).then((res) => {
-              if (res.status === 200) {
-                swal.fire({
-                  icon: 'success',
-                  text: '수정되었습니다.',
-                  confirmButtonText: '확인',
-                  confirmButtonColor: '#289951',
-                  width: 400,
-                });
-                getUser();
-              }
-            });
-          } catch (err: any) {
-            swal.fire({
-              icon: 'warning',
-              text: err.response.data.message,
-              confirmButtonText: '확인',
-              confirmButtonColor: '#289951',
-              width: 400,
-            });
+    if (!cookies.get('refreshToken')) {
+      navigate('/sign-in');
+    } else {
+      swal
+        .fire({
+          icon: 'question',
+          text: '회원정보를 수정하시겠습니까?',
+          confirmButtonText: '확인',
+          confirmButtonColor: '#289951',
+          showCancelButton: true,
+          cancelButtonText: '취소',
+          width: 400,
+        })
+        .then(async (result) => {
+          if (result.isConfirmed) {
+            try {
+              await axios({
+                method: 'PUT',
+                url: `${process.env.REACT_APP_API_URL}/user/update`,
+                headers: {
+                  Authorization: cookies.get('accessToken'),
+                },
+                data: {
+                  name: name,
+                  birth: birth,
+                  representativeName: ceo,
+                  phoneNumber: phone,
+                  companyRegistrationNumber: saupja,
+                  corporateRegistrationNumber: beobin,
+                  zipcode: zip,
+                  basicAddress: basic,
+                  detailedAddress: detail,
+                },
+              }).then((res) => {
+                if (res.status === 200) {
+                  swal.fire({
+                    icon: 'success',
+                    text: '수정되었습니다.',
+                    confirmButtonText: '확인',
+                    confirmButtonColor: '#289951',
+                    width: 400,
+                  });
+                  getUser();
+                }
+              });
+            } catch (err: any) {
+              swal.fire({
+                icon: 'warning',
+                text: err.response.data.message,
+                confirmButtonText: '확인',
+                confirmButtonColor: '#289951',
+                width: 400,
+              });
+            }
           }
-        }
-      });
+        });
+    }
   };
   return (
     <>

--- a/src/pages/OrderOk/index.tsx
+++ b/src/pages/OrderOk/index.tsx
@@ -13,6 +13,14 @@ export const OrderOk = () => {
   const cookies = new Cookies();
   const jwt = cookies.get('accessToken');
 
+  const movePaymentInfo = () => {
+    if (!cookies.get('refreshToken')) {
+      navigate('/sign-in');
+    } else {
+      navigate('/mypage-od');
+    }
+  };
+
   useEffect(() => {
     const deleteCartItem = async () => {
       let items = state.paymentDataId.map((itemId: any) => 'itemId=' + itemId + '&');
@@ -48,7 +56,7 @@ export const OrderOk = () => {
         </S.OrderInfoWrap>
         <S.BtnArea>
           <S.WhiteBtn onClick={() => navigate('/')}>쇼핑 계속하기</S.WhiteBtn>
-          <S.GreenBtn onClick={() => navigate('/mypage-od')}>결제 내역보기</S.GreenBtn>
+          <S.GreenBtn onClick={() => movePaymentInfo()}>결제 내역보기</S.GreenBtn>
         </S.BtnArea>
       </S.ContentContainer>
     </S.Container>

--- a/src/pages/SignIn/index.tsx
+++ b/src/pages/SignIn/index.tsx
@@ -34,13 +34,13 @@ export const SignIn = () => {
     setPw(e);
   };
   //로그인
-  const signIn = async () => {
+  const login = async () => {
     //엑세트토큰 쿠키만료시간
     const tokenExpires = new Date();
-    tokenExpires.setMinutes(tokenExpires.getMinutes() + 1);
+    tokenExpires.setMinutes(tokenExpires.getMinutes() + 10);
     //리프레시토큰 쿠키만료시간
     const rtokenExpires = new Date();
-    rtokenExpires.setMinutes(tokenExpires.getMinutes() + 5);
+    rtokenExpires.setMinutes(tokenExpires.getMinutes() + 60);
     try {
       await axios
         .post(
@@ -105,6 +105,12 @@ export const SignIn = () => {
     }
   };
 
+  const onKeyDownEnter = (e: any) => {
+    if (e.key === 'Enter') {
+      login();
+    }
+  };
+
   //회원가입
   const navigateSignUp = () => {
     navigate('/sign-up1');
@@ -141,7 +147,11 @@ export const SignIn = () => {
                 <label htmlFor='password'>패스워드</label>
               </S.LabelWrap>
               <S.InputWrap>
-                <S.InputForm type='password' onChange={(e) => onChangePw(e.target.value)} />
+                <S.InputForm
+                  type='password'
+                  onChange={(e) => onChangePw(e.target.value)}
+                  onKeyDown={(e) => onKeyDownEnter(e)}
+                />
               </S.InputWrap>
             </S.InputLine>
           </S.InputContainer>
@@ -164,7 +174,7 @@ export const SignIn = () => {
             </S.Span>
           </S.SignText>
           <div>
-            <S.Btn onClick={() => signIn()}>로그인</S.Btn>
+            <S.Btn onClick={() => login()}>로그인</S.Btn>
             {/* <S.Social>
               <S.SocialBtn onClick={test}>구글로 로그인하기</S.SocialBtn>
               <S.SocialBtn onClick={test} style={{ backgroundColor: '#FDDC3F' }}>


### PR DESCRIPTION
## ⭐ 개요
Header, 여러가지 이슈해결

## 📋 작업사항
- [x] 주문하기페이지 리프레쉬토큰 없을시 로그인화면으로 이동
- [x] 주문완료페이지 결제내역보기 버튼 리프레쉬토큰 없을시 로그인화면으로 이동
- [x] 같은 route여도 새로고침 되도록 수정
- [x] 아이템리스트 네비게이션 같은 route여도 새로고침되도록 수정
- [x] 마이페이지 내정보, 비밀번호변경, 회원탈퇴 리프레쉬토큰 만료시 로그인페이지로 이동
- [x] 장바구니 토큰재발급시 체크박스 초기화현상 막기
- [x] 결제창 열고 30분 경과시 메인페이지로 이동
- [x] 로그인페이지 엔터버튼으로 로그인가능 하도록 수정


